### PR TITLE
Pin assignments for testing with VIC-IIe adapter

### DIFF
--- a/testcircuit/README.md
+++ b/testcircuit/README.md
@@ -17,36 +17,37 @@ it will cause damage to connect some other signal source to these outputs.
 
 ## Wiring the power 
 
-| Power input  | Signal generator | VIC adapter |
-| ------------ | ---------------- | ----------- |
-| +5V          | RFCONC2 1        | Pin 40      |
-| GND          | SW1 3            | Pin 20      |
+| Power input  | Signal generator | VIC adapter | VIC-IIe adapter |
+| ------------ | ---------------- | ----------- | --------------- |
+| +5V          | RFCONC2 1        | Pin 40      | Pin 48          |
+| GND          | SW1 3            | Pin 20      | Pin 24          |
 
 ## Wiring up the signal generator outputs to the VIC adapter
 
-| FPGA pin | Signal generator | VIC adapter  | Signal      |
-| -------- | ---------------- | ------------ | ----------- |
-| 74       | GPIO1 1          | Pin 1        | DB6         |
-| 76       | GPIO1 3          | Pin 2        | DB5         |
-| 78       | GPIO1 5          | Pin 3        | DB4         |
-| 80       | GPIO1 7          | Pin 4        | DB3         |
-| 87       | GPIO1 9          | Pin 5        | DB2         |
-| 91       | GPIO1 11         | Pin 6        | DB1         |
-| 97       | GPIO1 13         | Pin 7        | DB0         |
-| 99       | GPIO1 15         | Pin 10       | CS          |
-| 101      | GPIO1 17         | Pin 11       | RW          |
-| -        | GND              | Pin 12       | BA (unused) |
-| 105      | GPIO1 19         | Pin 16       | AEC         |
-| 106      | GPIO1 20         | Pin 17       | PHI0        |
-| 103      | GPIO1 18         | Pin 24       | A0          |
-| 100      | GPIO1 16         | Pin 25       | A1          |
-| 98       | GPIO1 14         | Pin 26       | A2          |
-| 92       | GPIO1 12         | Pin 27       | A3          |
-| 88       | GPIO1 10         | Pin 28       | A4          |
-| 81       | GPIO1 8          | Pin 29       | A5          |
-| 79       | GPIO1 6          | Pin 35       | DB11        |
-| 77       | GPIO1 4          | Pin 36       | DB10        |
-| 75       | GPIO1 2          | Pin 37       | DB9         |
-| 39       | SW1 1            | Pin 38       | DB8         |
-| 40       | SW1 2            | Pin 39       | DB7         |
+| FPGA pin | Signal generator | VIC adapter  | VIC-IIe adapter | Signal      |
+| -------- | ---------------- | ------------ | --------------- | ----------- |
+| 74       | GPIO1 1          | Pin 1        | Pin 1           | DB6         |
+| 76       | GPIO1 3          | Pin 2        | Pin 2           | DB5         |
+| 78       | GPIO1 5          | Pin 3        | Pin 3           | DB4         |
+| 80       | GPIO1 7          | Pin 4        | Pin 4           | DB3         |
+| 87       | GPIO1 9          | Pin 5        | Pin 5           | DB2         |
+| 91       | GPIO1 11         | Pin 6        | Pin 6           | DB1         |
+| 97       | GPIO1 13         | Pin 7        | Pin 7           | DB0         |
+| 99       | GPIO1 15         | Pin 10       | Pin 13          | CS          |
+| 101      | GPIO1 17         | Pin 11       | Pin 14          | RW          |
+| -        | GND              | Pin 12       | Pin 10          | BA (unused) |
+| 105      | GPIO1 19         | Pin 16       | Pin 12          | AEC         |
+| 106      | GPIO1 20         | Pin 17       | Pin 18          | PHI0/1MHz   |
+| 103      | GPIO1 18         | Pin 24       | Pin 32          | A0          |
+| 100      | GPIO1 16         | Pin 25       | Pin 33          | A1          |
+| 98       | GPIO1 14         | Pin 26       | Pin 34          | A2          |
+| 92       | GPIO1 12         | Pin 27       | Pin 35          | A3          |
+| 88       | GPIO1 10         | Pin 28       | Pin 36          | A4          |
+| 81       | GPIO1 8          | Pin 29       | Pin 37          | A5          |
+| 79       | GPIO1 6          | Pin 35       | Pin 43          | DB11        |
+| 77       | GPIO1 4          | Pin 36       | Pin 44          | DB10        |
+| 75       | GPIO1 2          | Pin 37       | Pin 45          | DB9         |
+| 39       | SW1 1            | Pin 38       | Pin 46          | DB8         |
+| 40       | SW1 2            | Pin 39       | Pin 47          | DB7         |
 
+_(Most of the pins on both adapters are in the same location relative to pin 1, only the five pins 10-18 are in different locations)_


### PR DESCRIPTION
This PR adds the pin assignments if using a VIC-IIe adapter instead of the original VIC-II adapter. Most of the pins are in the same location relative to pin 1, just pins 10-18 need to be adjusted. Using a VIC-IIe adapter and these pin assignments I got the same test pattern.